### PR TITLE
Initialize skeleton for chronic disease platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Chronic Disease Management Platform
+
+This repository provides a minimal skeleton for a chronic disease management platform. It demonstrates a microservice-based backend using FastAPI and a placeholder for a frontend built with React.
+
+## Structure
+
+- `backend/` – contains a simple FastAPI service for patient management.
+- `frontend/` – placeholder directory for a React application.
+- `docker-compose.yml` – demonstrates how to run services using Docker.
+
+## Running the backend
+
+```
+cd backend
+pip install -r requirements.txt
+uvicorn patient_service.main:app --reload
+```
+
+The server will start on `http://localhost:8000` with a simple patients API.
+
+## Future work
+
+This skeleton can be expanded with additional services, authentication, notifications, data integration, and a full frontend UI as described in the design proposal.

--- a/backend/patient_service/Dockerfile
+++ b/backend/patient_service/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/patient_service/main.py
+++ b/backend/patient_service/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List
+
+app = FastAPI(title="Chronic Disease Management Platform")
+
+class Patient(BaseModel):
+    id: int | None = None
+    name: str
+    condition: str
+    risk_level: str
+
+patients: List[Patient] = []
+
+@app.get("/patients", response_model=List[Patient])
+def get_patients():
+    return patients
+
+@app.post("/patients", response_model=Patient)
+def add_patient(patient: Patient):
+    patient.id = len(patients) + 1
+    patients.append(patient)
+    return patient

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  patient-service:
+    build: ./backend/patient_service
+    ports:
+      - "8000:8000"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdm-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "echo 'React app placeholder'"
+  }
+}

--- a/index
+++ b/index
@@ -1,1 +1,1 @@
-
+Placeholder file.


### PR DESCRIPTION
## Summary
- add minimal FastAPI patient service with Dockerfile
- add Docker Compose setup and requirements
- stub frontend configuration
- document structure in README
- add `.gitignore` for common artifacts

## Testing
- `python -m py_compile backend/patient_service/main.py`

------
https://chatgpt.com/codex/tasks/task_e_684e98b2f7c483268ddeb04681e65bf7